### PR TITLE
Rewrite to not use the EKS Terraform Module

### DIFF
--- a/terraform/aws/addons.tf
+++ b/terraform/aws/addons.tf
@@ -1,0 +1,39 @@
+# Allow roles to assume permissions with their OIDC credentials,
+# for use with IRSA
+data "aws_iam_policy_document" "assume_role_with_oidc" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.cluster_oidc.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+  }
+}
+
+# Setup the EBS CSI Driver addon - https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
+# Required for EBS volumes to be provisioned and attached
+resource "aws_iam_role" "ebs_provisioner" {
+  name               = "${var.cluster_name}-eks-ebs-provisioner"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_with_oidc.json
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_provisioner" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+  role       = aws_iam_role.ebs_provisioner.name
+}
+
+resource "aws_eks_addon" "ebs_provisioner" {
+  cluster_name                = aws_eks_cluster.cluster.name
+  addon_name                  = "aws-ebs-csi-driver"
+  # Fetched version for current version from
+  # eksctl utils describe-addon-versions --kubernetes-version <kubernetes-version>
+  addon_version               = "v1.20.0-eksbuild.1"
+  resolve_conflicts_on_create = "OVERWRITE"
+  service_account_role_arn  = aws_iam_role.ebs_provisioner.arn
+  depends_on = [
+    aws_iam_role_policy_attachment.ebs_provisioner
+  ]
+}

--- a/terraform/aws/bakeries/default-us-west-2.tfvars
+++ b/terraform/aws/bakeries/default-us-west-2.tfvars
@@ -1,8 +1,8 @@
 # Default bakery run for pangeo-forge
 region = "us-west-2"
 
-cluster_name = "pangeo-forge-test"
+cluster_name = "pangeo-forge-test-1"
 
-buckets = ["yuvipanda-test1"]
+buckets = ["yuvipanda-forge-test-1"]
 
 prometheus_hostname = "prometheus.us-west-2.aws.bakeries.pangeo-forge.omgwtf.in"

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.29"
+      version = "~> 5.8"
     }
   }
 }

--- a/terraform/aws/nodes.tf
+++ b/terraform/aws/nodes.tf
@@ -1,0 +1,62 @@
+resource "aws_iam_role" "nodegroup" {
+  name = "${var.cluster_name}-nodegroup-role"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "node_worker_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.nodegroup.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_worker_cni_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.nodegroup.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_worker_ecr_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.nodegroup.name
+}
+
+resource "aws_eks_node_group" "core_nodes" {
+  cluster_name    = aws_eks_cluster.cluster.name
+  node_group_name = "core"
+  node_role_arn   = aws_iam_role.nodegroup.arn
+
+  # FIXME: Need to restrict this to a single AZ maybe
+  subnet_ids = data.aws_subnets.default.ids
+
+  instance_types = [var.instance_type]
+
+  scaling_config {
+    desired_size = 1
+    max_size     = var.max_instances
+    min_size     = 0
+  }
+
+  lifecycle {
+    # Allow cluster-autoscaler to change the size of nodepool without messing up terraform
+    ignore_changes = [scaling_config[0].desired_size]
+  }
+  update_config {
+    max_unavailable = 1
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.node_worker_policy_attachment,
+    aws_iam_role_policy_attachment.node_worker_cni_policy_attachment,
+    aws_iam_role_policy_attachment.node_worker_ecr_policy_attachment
+  ]
+}

--- a/terraform/aws/operator.tf
+++ b/terraform/aws/operator.tf
@@ -13,7 +13,7 @@ resource "helm_release" "cert_manager" {
   }
   wait = true
   depends_on = [
-    module.eks
+    aws_eks_cluster.cluster
   ]
 }
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -28,7 +28,7 @@ variable "max_instances" {
 }
 
 variable "flink_operator_version" {
-  default     = "1.3.1"
+  default     = "1.5.0"
   description = <<-EOT
   Version of Flink Operator to install.
   EOT


### PR DESCRIPTION
The EKS terraform module has generally been super flaky, and caused extra complications around opinionated networking choices that have not been worth it. It was originally picked as an 'easy' way to get an EKS cluster up and running, as the primitives available in terraform are a bit too primitive. However, as it has caused more trouble than its worth, this PR completely strips it out and uses just terraform + bare AWS provisioner to set the infrastructure up.

While we are here, version upgrades have also been performed.

The old terraform + cluster was torn down, but the S3 bucket with the data is still around.

Fixes https://github.com/yuvipanda/pangeo-forge-cloud-federation/issues/3