### PR TITLE
add conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: terraform
+channels:
+  - conda-forge
+dependencies:
+  - awscli
+  - terraform
+  - ca-certificates
+  - certifi
+  - openssl


### PR DESCRIPTION
This is sufficient for deploying (it installs AWS CLI v1), but for management of the cluster I needed to install the [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) (which currently can't be conda or pip installed) and [kubectl from AWS](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html) so that I could run k9s (installed from a binary on the [release page](https://github.com/derailed/k9s/releases))